### PR TITLE
Enable health and info endpoints and update README. Implements #11.

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,13 @@ or (Windows):
 
     ./mvnw.cmd clean verify
 
-To package as a docker image:
+To package:
 
     ./mvnw clean install
+    
+To build a Docker image named `hotelsdotcom/pitchfork`:
+
+    docker build -t hotelsdotcom/pitchfork .
     
 #### Run
 
@@ -38,9 +42,22 @@ You can override the default properties by with environment variables (macro cas
 
     docker run -p 8080:8080 -e PITCHFORK_FORWARDERS_HAYSTACK_ENABLED=false hotelsdotcom/pitchfork:latest
 
-Or you can run it as a normal Java application:
+You can also run it as a normal Java application:
 
     java -jar pitchfork.jar
+    
+Or even as a Spring Boot application:
+
+    mvn spring-boot:run
+    
+##### Health check
+
+The service exposes the following endpoints that can be used to test the app's health and to retrieve useful info:
+
+url       | Description
+----------|------------
+`/health` | Shows application health information.
+`/info`   | Displays application info.
 
 ##### Properties
 

--- a/pom.xml
+++ b/pom.xml
@@ -60,6 +60,11 @@
       <version>${spring.version}</version>
     </dependency>
     <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-actuator</artifactId>
+      <version>2.0.5.RELEASE</version>
+    </dependency>
+    <dependency>
       <groupId>org.apache.kafka</groupId>
       <artifactId>kafka-clients</artifactId>
       <version>0.11.0.3</version>

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -15,7 +15,7 @@ pitchfork:
         bootstrap-servers: kafka-service:9092
         topic: proto-spans
     logging:
-      enabled: false
+      enabled: true
       log-full-span: false
     zipkin:
       http:
@@ -24,3 +24,15 @@ pitchfork:
         max-inflight-requests: 256
         write-timeout-millis: 10000
         compression-enabled: true
+
+management:
+  endpoints:
+    web:
+      exposure:
+        include: health,info
+      base-path: /
+info:
+  app:
+    name: Pitchfork
+    description: Pitchfork lifts Zipkin tracing data into Haystack.
+    readme: https://github.com/HotelsDotCom/pitchfork/blob/master/README.md


### PR DESCRIPTION
Both endpoints are exposed by Spring Actuator.
`/health` returns:
```
{
  "status": "UP"
}
```

and `/info` returns:
```
{
  "app": {
    "name": "Pitchfork",
    "description": "Pitchfork lifts Zipkin tracing data into Haystack.",
    "readme": "https://github.com/HotelsDotCom/pitchfork/blob/master/README.md"
  }
}
``` 