### PR TITLE
Fail fast by throwing exception in ZipkinController init method

### DIFF
--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/ZipkinController.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/ZipkinController.java
@@ -62,7 +62,7 @@ public class ZipkinController {
     @PostConstruct
     public void init() {
         if (spanForwarders.length == 0) {
-            logger.warn("No span forwarders configured. See README.md for a list of available forwarders.");
+            throw new IllegalStateException("No span forwarders configured. See README.md for a list of available forwarders.");
         }
     }
 


### PR DESCRIPTION
Following up https://github.com/HotelsDotCom/pitchfork/pull/19#issuecomment-442064228

Failing fast is the right thing to do - the app shouldn't start if it isn't configured correctly, and it's ok for it to error in the event of problems with its dependencies.