### PR TITLE
Multiple outputs when using Kafka ingress

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ SERVER_PORT                                                    | 9411
 PITCHFORK_VALIDATORS_ACCEPT_NULL_TIMESTAMPS                    | true
 PITCHFORK_VALIDATORS_MAX_TIMESTAMP_DRIFT_SECONDS               | 3600
 PITCHFORK_INGRESS_KAFKA_ENABLED                                | false
-PITCHFORK_INGRESS_BOOTSTRAP_SERVERS                            | kafka-service:9092
-PITCHFORK_INGRESS_SOURCE_TOPICS                                | zipkin
-PITCHFORK_INGRESS_SOURCE_FORMAT                                | JSON_V2
+PITCHFORK_INGRESS_KAFKA_BOOTSTRAP_SERVERS                            | kafka-service:9092
+PITCHFORK_INGRESS_KAFKA_SOURCE_TOPICS                                | zipkin
+PITCHFORK_INGRESS_KAFKA_SOURCE_FORMAT                                | JSON_V2
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_ENABLED                    | false
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_BOOTSTRAP_SERVERS          | kafka-service:9092
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_TOPIC                      | proto-spans

--- a/README.md
+++ b/README.md
@@ -98,9 +98,9 @@ SERVER_PORT                                                    | 9411
 PITCHFORK_VALIDATORS_ACCEPT_NULL_TIMESTAMPS                    | true
 PITCHFORK_VALIDATORS_MAX_TIMESTAMP_DRIFT_SECONDS               | 3600
 PITCHFORK_INGRESS_KAFKA_ENABLED                                | false
-PITCHFORK_INGRESS_KAFKA_BOOTSTRAP_SERVERS                            | kafka-service:9092
-PITCHFORK_INGRESS_KAFKA_SOURCE_TOPICS                                | zipkin
-PITCHFORK_INGRESS_KAFKA_SOURCE_FORMAT                                | JSON_V2
+PITCHFORK_INGRESS_KAFKA_BOOTSTRAP_SERVERS                      | kafka-service:9092
+PITCHFORK_INGRESS_KAFKA_SOURCE_TOPICS                          | zipkin
+PITCHFORK_INGRESS_KAFKA_SOURCE_FORMAT                          | JSON_V2
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_ENABLED                    | false
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_BOOTSTRAP_SERVERS          | kafka-service:9092
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_TOPIC                      | proto-spans

--- a/README.md
+++ b/README.md
@@ -101,7 +101,6 @@ PITCHFORK_INGRESS_KAFKA_ENABLED                                | false
 PITCHFORK_INGRESS_BOOTSTRAP_SERVERS                            | kafka-service:9092
 PITCHFORK_INGRESS_SOURCE_TOPICS                                | zipkin
 PITCHFORK_INGRESS_SOURCE_FORMAT                                | JSON_V2
-PITCHFORK_FORWARDERS_THREADPOOL_SIZE                           | 50
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_ENABLED                    | false
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_BOOTSTRAP_SERVERS          | kafka-service:9092
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_TOPIC                      | proto-spans

--- a/README.md
+++ b/README.md
@@ -97,6 +97,11 @@ Description                                                    | Default
 SERVER_PORT                                                    | 9411
 PITCHFORK_VALIDATORS_ACCEPT_NULL_TIMESTAMPS                    | true
 PITCHFORK_VALIDATORS_MAX_TIMESTAMP_DRIFT_SECONDS               | 3600
+PITCHFORK_INGRESS_KAFKA_ENABLED                                | false
+PITCHFORK_INGRESS_BOOTSTRAP_SERVERS                            | kafka-service:9092
+PITCHFORK_INGRESS_SOURCE_TOPICS                                | zipkin
+PITCHFORK_INGRESS_SOURCE_FORMAT                                | JSON_V2
+PITCHFORK_FORWARDERS_THREADPOOL_SIZE                           | 50
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_ENABLED                    | false
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_BOOTSTRAP_SERVERS          | kafka-service:9092
 PITCHFORK_FORWARDERS_HAYSTACK_KAFKA_TOPIC                      | proto-spans

--- a/pom.xml
+++ b/pom.xml
@@ -149,19 +149,19 @@
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>testcontainers</artifactId>
-      <version>1.9.1</version>
+      <version>1.10.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>kafka</artifactId>
-      <version>1.9.1</version>
+      <version>1.10.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.testcontainers</groupId>
       <artifactId>localstack</artifactId>
-      <version>1.9.1</version>
+      <version>1.10.6</version>
       <scope>test</scope>
     </dependency>
     <dependency>
@@ -192,6 +192,11 @@
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
       <version>3.1.3</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.zipkin.reporter2</groupId>
+      <artifactId>zipkin-sender-kafka11</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/ZipkinController.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/ZipkinController.java
@@ -21,7 +21,6 @@ import static org.springframework.web.reactive.function.server.ServerResponse.ok
 
 import java.util.Collection;
 import java.util.function.Function;
-import javax.annotation.PostConstruct;
 
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -31,35 +30,25 @@ import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.reactive.function.BodyInserters;
 import org.springframework.web.reactive.function.server.ServerRequest;
 import org.springframework.web.reactive.function.server.ServerResponse;
-import reactor.core.publisher.Flux;
-import reactor.core.publisher.Mono;
-import reactor.core.scheduler.Schedulers;
-import zipkin2.Span;
-import zipkin2.codec.SpanBytesDecoder;
 
+import com.hotels.service.tracing.zipkintohaystack.forwarders.Fork;
 import com.hotels.service.tracing.zipkintohaystack.forwarders.SpanForwarder;
 import com.hotels.service.tracing.zipkintohaystack.forwarders.haystack.SpanValidator;
+import reactor.core.publisher.Mono;
+import zipkin2.Span;
+import zipkin2.codec.SpanBytesDecoder;
 
 @RestController
 public class ZipkinController {
 
     private final Logger logger = LoggerFactory.getLogger(this.getClass());
 
-    private final SpanForwarder[] spanForwarders;
     private final SpanValidator spanValidator;
     private final Fork fork;
 
-    public ZipkinController(@Autowired SpanValidator spanValidator, Fork fork, @Autowired(required = false) SpanForwarder... spanForwarders) {
-        this.spanForwarders = spanForwarders == null ? new SpanForwarder[0] : spanForwarders;
+    public ZipkinController(@Autowired SpanValidator spanValidator, Fork fork) {
         this.spanValidator = spanValidator;
         this.fork = fork;
-    }
-
-    @PostConstruct
-    public void init() {
-        if (spanForwarders.length == 0) {
-            throw new IllegalStateException("No span forwarders configured. See README.md for a list of available forwarders.");
-        }
     }
 
     /**
@@ -83,11 +72,7 @@ public class ZipkinController {
                 .bodyToMono(byte[].class)
                 .flatMapIterable(decodeList(decoder))
                 .filter(spanValidator::isSpanValid)
-                .flatMap(span -> Flux.fromArray(spanForwarders)
-                    .flatMap(spanForwarder -> Mono.fromRunnable(() -> spanForwarder.process(span))
-                        .subscribeOn(Schedulers.elastic())
-                    )
-                )
+                .flatMap(fork::processSpan)
                 .doOnError(throwable -> logger.warn("operation=addSpans", throwable))
                 .then(ok().body(BodyInserters.empty()));
     }

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/forwarders/Fork.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/forwarders/Fork.java
@@ -24,7 +24,6 @@ import java.util.List;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
-import java.util.function.Function;
 
 import javax.annotation.PostConstruct;
 
@@ -35,12 +34,12 @@ import org.springframework.stereotype.Component;
 import zipkin2.Span;
 
 @Component
-public class ForwarderDelegator {
+public class Fork {
 
     private final SpanForwarder[] spanForwarders;
     private final ExecutorService threadPool;
 
-    public ForwarderDelegator(@Value ("${pitchfork.forwarders.threadpool.size}") int forwardersThreadpoolSize,
+    public Fork(@Value ("${pitchfork.forwarders.threadpool.size}") int forwardersThreadpoolSize,
                               @Autowired(required = false) SpanForwarder... spanForwarders) {
         this.spanForwarders = spanForwarders == null ? new SpanForwarder[0] : spanForwarders;
         this.threadPool = Executors.newFixedThreadPool(forwardersThreadpoolSize);
@@ -53,8 +52,8 @@ public class ForwarderDelegator {
         }
     }
 
-    public Function<Span, List<Future<Void>>> processSpans() {
-        return span -> Arrays.stream(spanForwarders)
+    public List<Future<Void>> processSpan(Span span) {
+        return Arrays.stream(spanForwarders)
                 .map(producer -> runAsync(() -> producer.process(span), threadPool))
                 .collect(toList());
     }

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/forwarders/ForwarderDelegator.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/forwarders/ForwarderDelegator.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
+package com.hotels.service.tracing.zipkintohaystack.forwarders;
+
+import static java.util.concurrent.CompletableFuture.runAsync;
+import static java.util.stream.Collectors.toList;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.function.Function;
+
+import javax.annotation.PostConstruct;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import zipkin2.Span;
+
+@Component
+public class ForwarderDelegator {
+
+    private final SpanForwarder[] spanForwarders;
+    private final ExecutorService threadPool;
+
+    public ForwarderDelegator(@Value ("${pitchfork.forwarders.threadpool.size}") int forwardersThreadpoolSize,
+                              @Autowired(required = false) SpanForwarder... spanForwarders) {
+        this.spanForwarders = spanForwarders == null ? new SpanForwarder[0] : spanForwarders;
+        this.threadPool = Executors.newFixedThreadPool(forwardersThreadpoolSize);
+    }
+
+    @PostConstruct
+    public void init() {
+        if (spanForwarders.length == 0) {
+            throw new IllegalStateException("No span forwarders configured. See README.md for a list of available forwarders.");
+        }
+    }
+
+    public Function<Span, List<Future<Void>>> processSpans() {
+        return span -> Arrays.stream(spanForwarders)
+                .map(producer -> runAsync(() -> producer.process(span), threadPool))
+                .collect(toList());
+    }
+}

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/kbridge/KafkaBridge.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/kbridge/KafkaBridge.java
@@ -68,7 +68,7 @@ public class KafkaBridge {
         builder.stream(pitchForkConfig.getSourceTopics(), Consumed.with(Serdes.ByteArray(), serde))
                 .flatMapValues((ValueMapper<List<zipkin2.Span>, Iterable<zipkin2.Span>>) value -> value)
                 .filter((key, span) -> spanValidator.isSpanValid(span))
-                .foreach((key, span) -> fork.processSpan(span)); // TODO: error handling
+                .foreach((key, span) -> fork.processSpan(span).subscribe()); // TODO: error handling
 
         Properties properties = new Properties();
         properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, pitchForkConfig.getBootstrapServers());

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/kbridge/KafkaBridge.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/kbridge/KafkaBridge.java
@@ -1,6 +1,20 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.hotels.service.tracing.zipkintohaystack.kbridge;
-
-import static com.hotels.service.tracing.zipkintohaystack.forwarders.haystack.HaystackDomainConverter.fromZipkinV2;
 
 import java.util.List;
 import java.util.Properties;
@@ -9,24 +23,23 @@ import javax.annotation.PostConstruct;
 import javax.annotation.PreDestroy;
 import javax.inject.Inject;
 
+import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.Serde;
 import org.apache.kafka.common.serialization.Serdes;
 import org.apache.kafka.streams.KafkaStreams;
-import org.apache.kafka.streams.KeyValue;
 import org.apache.kafka.streams.StreamsBuilder;
 import org.apache.kafka.streams.StreamsConfig;
 import org.apache.kafka.streams.errors.LogAndContinueExceptionHandler;
 import org.apache.kafka.streams.kstream.Consumed;
-import org.apache.kafka.streams.kstream.KeyValueMapper;
-import org.apache.kafka.streams.kstream.Produced;
 import org.apache.kafka.streams.kstream.ValueMapper;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Component;
 
-import com.expedia.open.tracing.Span;
 import com.hotels.service.tracing.zipkintohaystack.PitchForkConfig;
+import com.hotels.service.tracing.zipkintohaystack.forwarders.ForwarderDelegator;
+import com.hotels.service.tracing.zipkintohaystack.forwarders.haystack.SpanValidator;
 
 @ConditionalOnProperty(name = "pitchfork.ingress.kafka.enabled", havingValue = "true")
 @Component
@@ -36,35 +49,34 @@ public class KafkaBridge {
 
     private KafkaStreams stream;
 
+    private final PitchForkConfig pitchForkConfig;
+    private final ForwarderDelegator forwarderDelegator;
+    private final SpanValidator spanValidator;
+
     @Inject
-    PitchForkConfig pitchForkConfig;
+    public KafkaBridge(PitchForkConfig pitchForkConfig, ForwarderDelegator forwarderDelegator, SpanValidator spanValidator) {
+        this.pitchForkConfig = pitchForkConfig;
+        this.forwarderDelegator = forwarderDelegator;
+        this.spanValidator = spanValidator;
+    }
 
     @PostConstruct
-    public void KafkaBridge() {
+    public void initialize() {
         Serde<List<zipkin2.Span>> serde = buildSerde(pitchForkConfig.getSourceFormat());
-        Properties kafkaproperties = new Properties();
-        kafkaproperties.put("bootstrap.servers", pitchForkConfig.getBootstrapServers());
-
-        if (!kafkaproperties.containsKey(StreamsConfig.APPLICATION_ID_CONFIG)) {
-            kafkaproperties.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "pitchfork");
-        }
-        if (!kafkaproperties.containsKey(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG)) {
-            kafkaproperties.setProperty(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG,
-                    LogAndContinueExceptionHandler.class.getName());
-        }
 
         StreamsBuilder builder = new StreamsBuilder();
         builder.stream(pitchForkConfig.getSourceTopics(), Consumed.with(Serdes.ByteArray(), serde))
-                //avoid null messages
-                .filter((k, v) -> v != null)
                 .flatMapValues((ValueMapper<List<zipkin2.Span>, Iterable<zipkin2.Span>>) value -> value)
-                //no empty traceids
-                .filter((k, v) -> v.traceId() != null && !v.traceId().isEmpty())
-                .map((k, v) -> traceidKeyMapper.apply(k, v))
-                .mapValues(value -> value.toByteArray())
-                .to(pitchForkConfig.getHaystackTopic(), Produced.with(Serdes.String(), Serdes.ByteArray()));
+                .filter((key, value) -> spanValidator.isSpanValid(value))
+                .foreach((key, value) -> forwarderDelegator.processSpans().apply(value)); // TODO: error handling
 
-        stream = new KafkaStreams(builder.build(), kafkaproperties);
+        Properties properties = new Properties();
+        properties.setProperty(StreamsConfig.BOOTSTRAP_SERVERS_CONFIG, pitchForkConfig.getBootstrapServers());
+        properties.setProperty(StreamsConfig.APPLICATION_ID_CONFIG, "pitchfork");
+        properties.setProperty(ConsumerConfig.AUTO_OFFSET_RESET_CONFIG, "earliest");
+        properties.setProperty(StreamsConfig.DEFAULT_DESERIALIZATION_EXCEPTION_HANDLER_CLASS_CONFIG, LogAndContinueExceptionHandler.class.getName());
+
+        stream = new KafkaStreams(builder.build(), properties);
         stream.setUncaughtExceptionHandler((t, e) -> logger.error("Stream has been shut down!!", e));
         stream.start();
         logger.info("Stream processor for bridge has started");
@@ -87,13 +99,4 @@ public class KafkaBridge {
         }
         return serde;
     }
-
-    private KeyValueMapper<byte[], zipkin2.Span, KeyValue<String, Span>> traceidKeyMapper =
-            (key, value) -> {
-                //since we cannot trust the key to be the traceid, just map the key to the traceid
-                //from the span
-                Span hsSpan = fromZipkinV2(value);
-                return new KeyValue<>(hsSpan.getTraceId(), hsSpan);
-            };
-
 }

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/kbridge/ZipkinSerDes.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/kbridge/ZipkinSerDes.java
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 Expedia, Inc.
+ *
+ *       Licensed under the Apache License, Version 2.0 (the "License");
+ *       you may not use this file except in compliance with the License.
+ *       You may obtain a copy of the License at
+ *
+ *           http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *       Unless required by applicable law or agreed to in writing, software
+ *       distributed under the License is distributed on an "AS IS" BASIS,
+ *       WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *       See the License for the specific language governing permissions and
+ *       limitations under the License.
+ *
+ */
 package com.hotels.service.tracing.zipkintohaystack.kbridge;
 
 import java.util.List;
@@ -22,7 +38,7 @@ public enum ZipkinSerDes {
     public Serde<List<Span>> serde;
 
     ZipkinSerDes(SpanBytesDecoder decoder) {
-        ZipkinKafkaAdapter adapter = new ZipkinKafkaAdapter(decoder, SpanBytesEncoder.JSON_V2);
+        ZipkinKafkaAdapter adapter = new ZipkinKafkaAdapter(decoder, SpanBytesEncoder.JSON_V2); // TODO: we don't need to define the encoder as spans go through the normal forwarding process
         serde = Serdes.serdeFrom(adapter, adapter);
     }
 

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -31,11 +31,6 @@
       "description": "Encoding used for the spans in the Kafka topics."
     },
     {
-      "name": "pitchfork.forwarders.threadpool.size",
-      "type": "java.lang.Integer",
-      "description": "Number of threads for the parallelism of the forwarding of messages to different outputs."
-    },
-    {
       "name": "pitchfork.forwarders.haystack.kinesis.enabled",
       "type": "java.lang.Boolean",
       "description": "When true, creates a forwarder to Haystack Kinesis."

--- a/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -31,9 +31,9 @@
       "description": "Encoding used for the spans in the Kafka topics."
     },
     {
-      "name": "pitchfork.ingress.kafka.haystack-topic",
-      "type": "java.lang.String",
-      "description": "Name of Haystack's kafka topic."
+      "name": "pitchfork.forwarders.threadpool.size",
+      "type": "java.lang.Integer",
+      "description": "Number of threads for the parallelism of the forwarding of messages to different outputs."
     },
     {
       "name": "pitchfork.forwarders.haystack.kinesis.enabled",

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -12,8 +12,9 @@ pitchfork:
       source-topics:
         - zipkin
       source-format: JSON_V2
-      haystack-topic: proto-spans
   forwarders:
+    threadpool:
+      size: 50
     haystack:
       kinesis:
         enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -13,8 +13,6 @@ pitchfork:
         - zipkin
       source-format: JSON_V2
   forwarders:
-    threadpool:
-      size: 50
     haystack:
       kinesis:
         enabled: false

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ pitchfork:
     max-timestamp-drift-seconds: -1
   ingress:
     kafka:
-      enabled: true
+      enabled: false
       bootstrap-servers: kafka-service:9092
       source-topics:
         - zipkin

--- a/src/test/java/com/hotels/service/tracing/zipkintohaystack/ZipkinForwarderTest.java
+++ b/src/test/java/com/hotels/service/tracing/zipkintohaystack/ZipkinForwarderTest.java
@@ -3,16 +3,13 @@ package com.hotels.service.tracing.zipkintohaystack;
 import static java.util.concurrent.TimeUnit.SECONDS;
 
 import static org.awaitility.Awaitility.await;
-import static org.apache.commons.codec.binary.Hex.decodeHex;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThat;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
-import static com.hotels.service.tracing.zipkintohaystack.utils.TestHelpers.compress;
 import static zipkin2.codec.SpanBytesEncoder.JSON_V1;
-import static zipkin2.codec.SpanBytesEncoder.JSON_V2;
 
 import java.util.List;
-
-import javax.annotation.PostConstruct;
 
 import org.junit.BeforeClass;
 import org.junit.Test;
@@ -20,21 +17,20 @@ import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.boot.web.server.LocalServerPort;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.http.converter.protobuf.ProtobufHttpMessageConverter;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.containers.wait.strategy.LogMessageWaitStrategy;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.Message;
 import zipkin2.Endpoint;
-import zipkin2.proto3.ListOfSpans;
-import zipkin2.proto3.Span;
+import zipkin2.codec.Encoding;
+import zipkin2.reporter.AsyncReporter;
+import zipkin2.reporter.okhttp3.OkHttpSender;
 
 @DirtiesContext
 @RunWith(SpringRunner.class)
@@ -43,13 +39,11 @@ public class ZipkinForwarderTest {
 
     private static Integer ZIPKIN_PORT;
 
+    @LocalServerPort
+    private int localServerPort;
+
     @Autowired
     private TestRestTemplate restTemplate;
-
-    @PostConstruct
-    public void registerExtraMessageConverters() {
-        this.restTemplate.getRestTemplate().getMessageConverters().add(new ProtobufHttpMessageConverter());
-    }
 
     @BeforeClass
     public static void setup() {
@@ -75,7 +69,7 @@ public class ZipkinForwarderTest {
         String parentId = "d6318b5dfa0088fa";
         long timestamp = 1528386023537760L;
         int duration = 17636;
-        String localEndpoint = "abc";
+        String localEndpoint = "jsonv2";
 
         var zipkinSpan = zipkin2.Span.newBuilder()
                 .id(spanId)
@@ -86,14 +80,8 @@ public class ZipkinForwarderTest {
                 .localEndpoint(Endpoint.newBuilder().serviceName(localEndpoint).build())
                 .build();
 
-        byte[] bytes = JSON_V2.encodeList(List.of(zipkinSpan));
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Content-Type", "application/json");
-        HttpEntity<String> request = new HttpEntity<>(new String(bytes), headers);
-
-        ResponseEntity<String> responseFromVictim = this.restTemplate.postForEntity("/api/v2/spans", request, String.class);
-        assertEquals("Expected a 200 status from pitchfork", HttpStatus.OK, responseFromVictim.getStatusCode());
+        var reporter = setupReporter(Encoding.JSON, false);
+        reporter.report(zipkinSpan);
 
         // proxy is async, and zipkin is async too, so we retry our assertions until they are true
         await().atMost(30, SECONDS).untilAsserted(() -> {
@@ -103,7 +91,40 @@ public class ZipkinForwarderTest {
                     .getForEntity("http://localhost:" + ZIPKIN_PORT + "/api/v2/services", String.class);
 
             assertEquals(HttpStatus.OK, responseFromZipkin.getStatusCode());
-            assertEquals("[\"abc\"]", responseFromZipkin.getBody());
+            assertTrue(responseFromZipkin.getBody().contains("\"jsonv2\""));
+        });
+    }
+
+    @Test
+    public void shouldAcceptThriftAndForwardToZipkin() {
+        String spanId = "2696599e12b2a265";
+        String traceId = "3116bae014149aad";
+        String parentId = "d6318b5dfa0088fa";
+        long timestamp = 1528386023537760L;
+        int duration = 17636;
+        String localEndpoint = "thrift";
+
+        var zipkinSpan = zipkin2.Span.newBuilder()
+                .id(spanId)
+                .traceId(traceId)
+                .parentId(parentId)
+                .timestamp(timestamp)
+                .duration(duration)
+                .localEndpoint(Endpoint.newBuilder().serviceName(localEndpoint).build())
+                .build();
+
+        var reporter = setupReporter(Encoding.THRIFT, false);
+        reporter.report(zipkinSpan);
+
+        // proxy is async, and zipkin is async too, so we retry our assertions until they are true
+        await().atMost(30, SECONDS).untilAsserted(() -> {
+
+            // assert that traces were forwarded to zipkin by asking which services it knows about
+            ResponseEntity<String> responseFromZipkin = restTemplate
+                    .getForEntity("http://localhost:" + ZIPKIN_PORT + "/api/v2/services", String.class);
+
+            assertEquals(HttpStatus.OK, responseFromZipkin.getStatusCode());
+            assertTrue(responseFromZipkin.getBody().contains("\"thrift\""));
         });
     }
 
@@ -114,7 +135,7 @@ public class ZipkinForwarderTest {
         String parentId = "d6318b5dfa0088fa";
         long timestamp = 1528386023537760L;
         int duration = 17636;
-        String localEndpoint = "abc";
+        String localEndpoint = "compressedjsonv2";
 
         var zipkinSpan = zipkin2.Span.newBuilder()
                 .id(spanId)
@@ -125,15 +146,8 @@ public class ZipkinForwarderTest {
                 .localEndpoint(Endpoint.newBuilder().serviceName(localEndpoint).build())
                 .build();
 
-        byte[] bytes = JSON_V2.encodeList(List.of(zipkinSpan));
-
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Content-Type", "application/json");
-        headers.set("Content-Encoding", "gzip");
-        HttpEntity<byte[]> request = new HttpEntity<>(compress(bytes), headers);
-
-        ResponseEntity<String> responseFromVictim = this.restTemplate.postForEntity("/api/v2/spans", request, String.class);
-        assertEquals("Expected a 200 status from pitchfork", HttpStatus.OK, responseFromVictim.getStatusCode());
+        var reporter = setupReporter(Encoding.JSON, true);
+        reporter.report(zipkinSpan);
 
         // proxy is async, and zipkin is async too, so we retry our assertions until they are true
         await().atMost(30, SECONDS).untilAsserted(() -> {
@@ -143,7 +157,7 @@ public class ZipkinForwarderTest {
                     .getForEntity("http://localhost:" + ZIPKIN_PORT + "/api/v2/services", String.class);
 
             assertEquals(HttpStatus.OK, responseFromZipkin.getStatusCode());
-            assertEquals("[\"abc\"]", responseFromZipkin.getBody());
+            assertTrue(responseFromZipkin.getBody().contains("\"compressedjsonv2\""));
         });
     }
 
@@ -154,7 +168,7 @@ public class ZipkinForwarderTest {
         String parentId = "d6318b5dfa0088fa";
         long timestamp = 1528386023537760L;
         int duration = 17636;
-        String localEndpoint = "abc";
+        String localEndpoint = "jsonv1";
 
         var zipkinSpan = zipkin2.Span.newBuilder()
                 .id(spanId)
@@ -165,12 +179,11 @@ public class ZipkinForwarderTest {
                 .localEndpoint(Endpoint.newBuilder().serviceName(localEndpoint).build())
                 .build();
 
+        // We need to do our own reporting when using Json V1 as this has been deprecated and the standard zipkin reporter doesnt support this encoding any more
         byte[] bytes = JSON_V1.encodeList(List.of(zipkinSpan));
-
         HttpHeaders headers = new HttpHeaders();
         headers.set("Content-Type", "application/json");
         HttpEntity<String> request = new HttpEntity<>(new String(bytes), headers);
-
         ResponseEntity<String> responseFromVictim = this.restTemplate.postForEntity("/api/v1/spans", request, String.class);
         assertEquals("Expected a 200 status from pitchfork", HttpStatus.OK, responseFromVictim.getStatusCode());
 
@@ -182,7 +195,7 @@ public class ZipkinForwarderTest {
                     .getForEntity("http://localhost:" + ZIPKIN_PORT + "/api/v2/services", String.class);
 
             assertEquals(HttpStatus.OK, responseFromZipkin.getStatusCode());
-            assertEquals("[\"abc\"]", responseFromZipkin.getBody());
+            assertTrue(responseFromZipkin.getBody().contains("\"jsonv1\""));
         });
     }
 
@@ -193,27 +206,19 @@ public class ZipkinForwarderTest {
         String parentId = "d6318b5dfa0088fa";
         long timestamp = 1528386023537760L;
         int duration = 17636;
-        String localEndpoint = "abc";
+        String localEndpoint = "proto";
 
-        ListOfSpans listOfSpans = ListOfSpans.newBuilder().addSpans(
-                Span.newBuilder()
-                        .setId(ByteString.copyFrom(decodeHex(spanId.toCharArray())))
-                        .setTraceId(ByteString.copyFrom(decodeHex(traceId.toCharArray())))
-                        .setParentId(ByteString.copyFrom(decodeHex(parentId.toCharArray())))
-                        .setTimestamp(timestamp)
-                        .setDuration(duration)
-                        .setLocalEndpoint(zipkin2.proto3.Endpoint.newBuilder()
-                                .setServiceName(localEndpoint)
-                                .build())
-                        .build()
-        ).build();
+        var zipkinSpan = zipkin2.Span.newBuilder()
+                .id(spanId)
+                .traceId(traceId)
+                .parentId(parentId)
+                .timestamp(timestamp)
+                .duration(duration)
+                .localEndpoint(Endpoint.newBuilder().serviceName(localEndpoint).build())
+                .build();
 
-        HttpHeaders headers = new HttpHeaders();
-        headers.set("Content-Type", "application/x-protobuf");
-        HttpEntity<Message> request = new HttpEntity<>(listOfSpans, headers);
-
-        ResponseEntity<String> responseFromVictim = this.restTemplate.postForEntity("/api/v2/spans", request, String.class);
-        assertEquals("Expected a 200 status from pitchfork", HttpStatus.OK, responseFromVictim.getStatusCode());
+        var reporter = setupReporter(Encoding.PROTO3, false);
+        reporter.report(zipkinSpan);
 
         // proxy is async, and zipkin is async too, so we retry our assertions until they are true
         await().atMost(30, SECONDS).untilAsserted(() -> {
@@ -223,7 +228,19 @@ public class ZipkinForwarderTest {
                     .getForEntity("http://localhost:" + ZIPKIN_PORT + "/api/v2/services", String.class);
 
             assertEquals(HttpStatus.OK, responseFromZipkin.getStatusCode());
-            assertEquals("[\"abc\"]", responseFromZipkin.getBody());
+            assertTrue(responseFromZipkin.getBody().contains("\"proto\""));
         });
+    }
+
+    /**
+     * Create reporter.
+     */
+    private AsyncReporter<zipkin2.Span> setupReporter(Encoding encoding, boolean compressionEnabled) {
+        var sender = OkHttpSender.newBuilder()
+                .encoding(encoding)
+                .compressionEnabled(compressionEnabled)
+                .endpoint("http://localhost:" + localServerPort + "/api/v2/spans")
+                .build();
+        return AsyncReporter.create(sender);
     }
 }

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -12,8 +12,6 @@ pitchfork:
         - zipkin
       source-format: JSON_V2
   forwarders:
-    threadpool:
-      size: 50
     haystack:
       kinesis:
         enabled: false

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -11,8 +11,9 @@ pitchfork:
       source-topics:
         - zipkin
       source-format: JSON_V2
-      haystack-topic: proto-spans
   forwarders:
+    threadpool:
+      size: 50
     haystack:
       kinesis:
         enabled: false


### PR DESCRIPTION
Multiple outputs when using Kafka ingress (currently we can only output to Kafka when using Kafka as the source of data for spans).

I'm not sure if Kafka Streams are the best fit since we have multiple outputs but I wanted to keep the number of changes low.