### PR TITLE
Add counters for spans processed and for invalid spans

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -15,6 +15,7 @@
     <zipkin-reporter.version>2.8.2</zipkin-reporter.version>
     <spring-boot.version>2.1.4.RELEASE</spring-boot.version>
     <junit-jupiter.version>5.4.2</junit-jupiter.version>
+    <mockito.version>2.27.0</mockito.version>
     <testcontainers.version>1.11.2</testcontainers.version>
     <micrometer.version>1.1.4</micrometer.version>
     <jackson.version>2.9.8</jackson.version>
@@ -197,6 +198,12 @@
       <groupId>org.junit.jupiter</groupId>
       <artifactId>junit-jupiter-params</artifactId>
       <version>${junit-jupiter.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <version>${mockito.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/ingresses/kafka/KafkaConsumerConfig.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/ingresses/kafka/KafkaConsumerConfig.java
@@ -29,6 +29,7 @@ import org.springframework.context.annotation.Configuration;
 
 import com.hotels.service.tracing.zipkintohaystack.forwarders.Fork;
 import com.hotels.service.tracing.zipkintohaystack.forwarders.haystack.SpanValidator;
+import com.hotels.service.tracing.zipkintohaystack.metrics.MetersProvider;
 
 @ConditionalOnProperty(name = "pitchfork.ingress.kafka.enabled", havingValue = "true")
 @Configuration
@@ -62,7 +63,7 @@ public class KafkaConsumerConfig {
     }
 
     @Bean
-    public KafkaRecordsConsumer kafkaRecordsConsumer(Fork fork, SpanValidator spanValidator, KafkaConsumer<String, byte[]> kafkaConsumer, KafkaIngressConfig config) {
-        return new KafkaRecordsConsumer(fork, spanValidator, kafkaConsumer, config);
+    public KafkaRecordsConsumer kafkaRecordsConsumer(Fork fork, SpanValidator spanValidator, KafkaConsumer<String, byte[]> kafkaConsumer, KafkaIngressConfig config, MetersProvider metersProvider) {
+        return new KafkaRecordsConsumer(fork, spanValidator, kafkaConsumer, config, metersProvider);
     }
 }

--- a/src/main/java/com/hotels/service/tracing/zipkintohaystack/metrics/MetersProvider.java
+++ b/src/main/java/com/hotels/service/tracing/zipkintohaystack/metrics/MetersProvider.java
@@ -1,0 +1,31 @@
+package com.hotels.service.tracing.zipkintohaystack.metrics;
+
+import javax.inject.Inject;
+
+import org.springframework.stereotype.Component;
+
+import io.micrometer.core.instrument.Counter;
+import io.micrometer.core.instrument.MeterRegistry;
+
+@Component
+public class MetersProvider {
+
+    private final MeterRegistry meterRegistry;
+
+    @Inject
+    public MetersProvider(MeterRegistry meterRegistry) {
+        this.meterRegistry = meterRegistry;
+    }
+
+    public Counter getSpansCounter(String protocol, String transport) {
+        return Counter.builder("counter.pitchfork.spans")
+                .tags("transport", transport, "protocol", protocol)
+                .register(meterRegistry);
+    }
+
+    public Counter getInvalidSpansCounter() {
+        return Counter.builder("counter.pitchfork.spans.invalid")
+                .tags("invalid", "true")
+                .register(meterRegistry);
+    }
+}


### PR DESCRIPTION
Still missing counters for spans that failed (either because deser failed, or because the upstream failed, ...).

In the Zipkin server the metrics are broken down by transport, in here they are by transport + encoding.
I think we have some degrees of freedom to make changes after this is released since the number of metrics is fairly small. We could add other things like bytes or messages (vs spans) that Zipkin server also has.