### PR TITLE
Fix links

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug-report.md
+++ b/.github/ISSUE_TEMPLATE/bug-report.md
@@ -1,6 +1,6 @@
 ---
 name: Bug report 
-about: Please check if there's an open [issue](https://github.com/HotelsDotCom/pitchfork/issues) for the same or a similar bug.
+about: Please check if there's an open issue for the same or a similar bug.
 
 ---
 

--- a/.github/ISSUE_TEMPLATE/feature.md
+++ b/.github/ISSUE_TEMPLATE/feature.md
@@ -1,6 +1,6 @@
 ---
 name: Feature Request
-about: Please check if there's an open [issue](https://github.com/HotelsDotCom/pitchfork/issues) for the same or a similar feature.
+about: Please check if there's an open issue for the same or a similar feature.
 
 ---
 

--- a/CODE-OF-CONDUCT.md
+++ b/CODE-OF-CONDUCT.md
@@ -55,7 +55,7 @@ further defined and clarified by project maintainers.
 ## Enforcement
 
 Instances of abusive, harassing, or otherwise unacceptable behaviour may be
-reported by contacting [a member of the project team](https://github.com/orgs/HotelsDotCom/teams/pitchfork/members). All
+reported by contacting [a member of the project team](https://github.com/orgs/HotelsDotCom/teams/pitchfork-committers/members). All
 complaints will be reviewed and investigated and will result in a response that
 is deemed necessary and appropriate to the circumstances. The project team is
 obligated to maintain confidentiality with regard to the reporter of an incident.


### PR DESCRIPTION
Fix team link in `CODE-OF-CONDUCT.md` and remove issues link from `./github` files.